### PR TITLE
ci: content/site変更時のみDeploy workflowを実行

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/deploy-pages.yml
+      - "content/**"
+      - "site/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 概要
- Deploy Cloudflare Pages workflow の push トリガーに paths フィルタを追加
- content/ または site/ 配下に変更がある場合のみ自動実行
- workflow_dispatch は維持（手動実行は引き続き可能）

## 変更ファイル
- .github/workflows/deploy-pages.yml